### PR TITLE
Fix/install and always on top

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,14 @@
 const { app, BrowserWindow, screen } = require('electron')
 
+// Handle Squirrel.Windows install/update/uninstall events.
+// When launched by the installer with --squirrel-* args, this module
+// creates/removes shortcuts and returns true so we quit immediately,
+// preventing a second overlay window from spawning alongside the real launch.
+if (require('electron-squirrel-startup')) {
+  app.quit()
+  return
+}
+
 const path = require('path')
 
 let win;

--- a/main.js
+++ b/main.js
@@ -38,6 +38,17 @@ function createWindow () {
   })
   win.setMenuBarVisibility(false)
   win.loadFile('index.html')
+
+  // The constructor's alwaysOnTop defaults to 'floating', which full-screen
+  // Chromium windows and some conferencing apps can still cover. 'screen-saver'
+  // is the highest standard level.
+  win.setAlwaysOnTop(true, 'screen-saver')
+  win.setVisibleOnAllWorkspaces(true)
+
+  // If another app steals focus and demotes our z-order, reassert it.
+  win.on('blur', () => {
+    win.setAlwaysOnTop(true, 'screen-saver')
+  })
 }
 
 app.whenReady().then(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "chromabro",
       "version": "0.5.0",
       "license": "ISC",
+      "dependencies": {
+        "electron-squirrel-startup": "^1.0.1"
+      },
       "devDependencies": {
         "@electron-forge/cli": "^7.10.2",
         "@electron-forge/maker-squirrel": "^7.10.2",
@@ -890,7 +893,6 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -1153,7 +1155,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -1814,7 +1815,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2103,7 +2103,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2713,6 +2712,30 @@
         "node": ">= 12.20.55"
       }
     },
+    "node_modules/electron-squirrel-startup": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/electron-squirrel-startup/-/electron-squirrel-startup-1.0.1.tgz",
+      "integrity": "sha512-sTfFIHGku+7PsHLJ7v0dRcZNkALrV+YEozINTW8X1nM//e5O3L+rfYuvSW00lmGHnYmUjARZulD8F2V8ISI9RA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^2.2.0"
+      }
+    },
+    "node_modules/electron-squirrel-startup/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/electron-squirrel-startup/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
@@ -2870,6 +2893,17 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -5764,7 +5798,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6513,7 +6546,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
         }
       ]
     }
+  },
+  "dependencies": {
+    "electron-squirrel-startup": "^1.0.1"
   }
 }


### PR DESCRIPTION
- Fixes the app boots a window during the install event and again when Squirrel launches the finished app normally hence the two overlays and the reset state
- Raise the z-level using `win.setAlwaysOnTop(true, 'screen-saver')`
- Re-assert on blur  `listen for win.on('blur', ...)` and call `setAlwaysOnTop(true, 'screen-saver')` again